### PR TITLE
Listing detail page now shows image properly

### DIFF
--- a/src/main/java/UI/ListingDetailPage.java
+++ b/src/main/java/UI/ListingDetailPage.java
@@ -27,6 +27,7 @@ public class ListingDetailPage extends Page implements ActionListener {
     private JLabel message;
     private JButton addToCartButton;
 
+
     public ListingDetailPage(Listing listing) throws IOException {
         super(listing.getTitle());
         this.listing = listing;
@@ -52,8 +53,11 @@ public class ListingDetailPage extends Page implements ActionListener {
         this.add(listingTitle);
 
         try {
-            BufferedImage rawImage = ImageIO.read(new File("src/main/java/image.JPG"));
-            JLabel img = new JLabel(new ImageIcon(rawImage));
+            String filepath = listing.getImagePath();
+            BufferedImage rawImage = ImageIO.read(new File(filepath));
+            Image scaled_image = rawImage.getScaledInstance(300, 220, Image.SCALE_SMOOTH);
+            JLabel img = new JLabel(new ImageIcon(scaled_image));
+
             img.setSize(300, 220);
             img.setLocation(350, 190);
             this.add(img);


### PR DESCRIPTION
get image from db (listing) and show it scaled.
I want to merge this so I can test it in conjunction with create listing page
![image](https://user-images.githubusercontent.com/65613404/205748678-24d06c63-f64c-4bea-8881-6f4185aae61f.png)
